### PR TITLE
Fix FakeStream is cutting down response part

### DIFF
--- a/src/Http/FakeStream.php
+++ b/src/Http/FakeStream.php
@@ -74,7 +74,7 @@ class FakeStream implements StreamInterface
         $index = $this->index;
 
         // Set the internal index to the end of the string
-        $this->index = $size - 1;
+        $this->index = $size;
 
         if ($index) {
             // Per PSR-7 spec, if we have seeked or read to a given position in
@@ -113,7 +113,7 @@ class FakeStream implements StreamInterface
      */
     public function eof(): bool
     {
-        return $this->index >= $this->getSize() - 1;
+        return $this->index >= $this->getSize();
     }
 
     /**
@@ -134,7 +134,7 @@ class FakeStream implements StreamInterface
         // Reset index based on legnth; should not be > EOF position.
         $size = $this->getSize();
         $this->index = $this->index + $length >= $size
-            ? $size - 1
+            ? $size
             : $this->index + $length;
 
         return $result;
@@ -177,7 +177,7 @@ class FakeStream implements StreamInterface
                         'Offset must be a negative number to be under the content size when using SEEK_END'
                     );
                 }
-                $this->index = ($size - 1) + $offset;
+                $this->index = $size + $offset;
                 break;
             default:
                 throw new InvalidArgumentException(

--- a/tests/Http/FakeStreamTest.php
+++ b/tests/Http/FakeStreamTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of the Makise-Co Framework
+ *
+ * World line: 0.571024a
+ * (c) Dmitry K. <coder1994@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace MakiseCo\Tests\Http;
+
+use MakiseCo\Http\FakeStream;
+use PHPUnit\Framework\TestCase;
+
+class FakeStreamTest extends TestCase
+{
+    private const DEFAULT_CONTENT = 'This is a test!';
+
+    public function testEmptyBody(): void
+    {
+        $stream = new FakeStream('');
+
+        $this->assertTrue($stream->eof());
+        $this->assertSame('', $stream->read(2));
+    }
+
+    public function testCrossCase(): void
+    {
+        $chunkedString = str_pad('', 8192 + 1, '0');
+
+        $stream = new FakeStream($chunkedString);
+        $read = 0;
+
+        while (!$stream->eof()) {
+            $content = $stream->read(8192);
+            $read += strlen($content);
+        }
+
+        $this->assertSame(8192 + 1, $read);
+    }
+
+    public function testGetContents(): void
+    {
+        $stream = new FakeStream(self::DEFAULT_CONTENT);
+        $content = $stream->getContents();
+
+        $this->assertSame(self::DEFAULT_CONTENT, $content);
+        $this->assertTrue($stream->eof());
+    }
+
+    public function testGetContentsReturnsOnlyFromIndexForward(): void
+    {
+        $stream = new FakeStream(self::DEFAULT_CONTENT);
+
+        $index = 10;
+        $stream->seek($index);
+
+        $this->assertSame(substr(self::DEFAULT_CONTENT, $index), $stream->getContents());
+    }
+}


### PR DESCRIPTION
Fix FakeStream is cutting down response part in case when body size is CHUNK_SIZE + 1